### PR TITLE
To fix the bug in 'getCovariate' function of 'exportMetadata' module

### DIFF
--- a/R/Export.R
+++ b/R/Export.R
@@ -332,7 +332,7 @@ exportMetadata <- function(outputFolder,
   ParallelLogger::logInfo("- covariate table")
   reference <- readRDS(file.path(outputFolder, "cmOutput", "outcomeModelReference.rds"))
   getCovariates <- function(analysisId) {
-    cmDataFolder <- reference$cohortMethodDataFile[analysisId][1]
+    cmDataFolder <- reference$cohortMethodDataFile[reference$analysisId==analysisId][1]
     cmData <- CohortMethod::loadCohortMethodData(file.path(outputFolder, "cmOutput", cmDataFolder))
     covariateRef <- collect(cmData$covariateRef)
     covariateRef <- covariateRef[, c("covariateId", "covariateName", "analysisId")]


### PR DESCRIPTION
The indexing should be based on "analysisId" of the analysis rather than numeric value of "analysisId".
This bug was found by Henry Morgan Stewart of IQVIA. 
@schuemie 